### PR TITLE
Relocated dependency

### DIFF
--- a/grabber/grabber.go
+++ b/grabber/grabber.go
@@ -1,7 +1,7 @@
 package grabber
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/tools"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/stomp.v1"

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/printserver"
 	"github.com/contester/printing3/tickets"
 	"github.com/contester/printing3/tools"

--- a/printserver/common.go
+++ b/printserver/common.go
@@ -3,7 +3,7 @@ package printserver
 import (
 	"log"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/tools"
 	"gopkg.in/stomp.v1"
 )

--- a/source_grabber/source_grabber.go
+++ b/source_grabber/source_grabber.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/tickets"
 	"github.com/contester/printing3/tools"
 

--- a/source_processor/source_processor.go
+++ b/source_processor/source_processor.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	// "code.google.com/p/go-charset/charset"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"code.google.com/p/log4go"
 	"github.com/contester/printing3/tickets"
 	"github.com/contester/printing3/tools"

--- a/tex_processor/tex_processor.go
+++ b/tex_processor/tex_processor.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"code.google.com/p/log4go"
 	"flag"
 	"fmt"

--- a/ticket_grabber/ticket_grabber.go
+++ b/ticket_grabber/ticket_grabber.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/tickets"
 	"github.com/contester/printing3/tools"
 	"github.com/jmoiron/sqlx"

--- a/ticket_processor/ticket_processor.go
+++ b/ticket_processor/ticket_processor.go
@@ -10,7 +10,7 @@ import (
 	"time"
 	"strings"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/contester/printing3/printserver"
 	"github.com/contester/printing3/tickets"
 	"github.com/contester/printing3/tools"

--- a/tickets/proto_helpers.go
+++ b/tickets/proto_helpers.go
@@ -3,7 +3,7 @@ package tickets
 
 import (
 	"bytes"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"compress/zlib"
 	"crypto/sha1"
 	"io"

--- a/tickets/tickets.pb.go
+++ b/tickets/tickets.pb.go
@@ -4,7 +4,7 @@
 
 package tickets
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 


### PR DESCRIPTION
"code.google.com/p/goprotobuf/proto" has moved to "github.com/golang/protobuf/proto"
Updated go import paths to reflect this change.